### PR TITLE
Add aarch64 support

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -23,11 +23,13 @@ readonly release="v1.11.0"
 declare -A hashes=(
     # sha256sums for v1.11.0.  Update this if you update the release.
     [linux-amd64]="231ec5ca8115e94c75a1f4fbada1a062b48822ca04f21f26e4cb1cd8973cd458"
+    [linux-arm64]="f9119deb1eeb6d730ee8b2e1a14d09cb45638f0447df23144229c5b3b3bc2408"
 )
 
 declare -A architectures=(
     # Map `uname -m -o` to bazelisk's precompiled binary target names.
     [x86_64 GNU/Linux]="linux-amd64"
+    [aarch64 GNU/Linux]="linux-arm64"
 )
 
 function os_arch() {

--- a/config/compiler.bzl
+++ b/config/compiler.bzl
@@ -111,6 +111,8 @@ def setup(
         "[SYSTEM_INCLUDES]": listify_flags(isystem, include_directories),
     }
     subst.update(substitutions)
+    if "host_arch" not in params:
+        params["host_arch"] = "x86_64"
 
     toolchain_config(
         name = name + "_config",
@@ -141,7 +143,7 @@ def setup(
     native.toolchain(
         name = "cc_toolchain_" + name,
         exec_compatible_with = [
-            "@platforms//cpu:x86_64",
+            "@platforms//cpu:" + params["host_arch"],
         ],
         target_compatible_with = constraints,
         toolchain = ":" + name,

--- a/config/registration.bzl
+++ b/config/registration.bzl
@@ -37,7 +37,8 @@ def crt_register_toolchains(
         native.register_toolchains("@crt//toolchains/cc65:all")
 
     if riscv32:
-        lowrisc_rv32imcb_repos(local = _maybe_archive(riscv32))
+        lowrisc_rv32imcb_repos(local = _maybe_archive(riscv32), host_arch = "x86_64")
+        lowrisc_rv32imcb_repos(local = _maybe_archive(riscv32), host_arch = "aarch64")
         native.register_execution_platforms("@crt//platforms/riscv32:all")
         native.register_toolchains("@crt//toolchains/lowrisc_rv32imcb:all")
 

--- a/toolchains/lowrisc_rv32imcb/BUILD.bazel
+++ b/toolchains/lowrisc_rv32imcb/BUILD.bazel
@@ -8,42 +8,51 @@ load("//platforms/riscv32:devices.bzl", "DEVICES")
 package(default_visibility = ["//visibility:public"])
 
 SYSTEM_INCLUDE_PATHS = [
-    "external/lowrisc_rv32imcb_files/lib/clang/16/include",
-    "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include",
-    "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include/c++/10.2.0",
-    "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include/c++/10.2.0/backward",
-    "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include/c++/10.2.0/riscv32-unknown-elf",
+    "external/lowrisc_rv32imcb_{}_files/lib/clang/16/include",
+    "external/lowrisc_rv32imcb_{}_files/riscv32-unknown-elf/include",
+    "external/lowrisc_rv32imcb_{}_files/riscv32-unknown-elf/include/c++/10.2.0",
+    "external/lowrisc_rv32imcb_{}_files/riscv32-unknown-elf/include/c++/10.2.0/backward",
+    "external/lowrisc_rv32imcb_{}_files/riscv32-unknown-elf/include/c++/10.2.0/riscv32-unknown-elf",
 ]
 
-filegroup(
-    name = "compiler_components",
+HOST_ARCHS = [
+    "x86_64",
+    "aarch64",
+]
+
+[filegroup(
+    name = "compiler_components" + host_arch,
     srcs = [
         "//toolchains/lowrisc_rv32imcb/wrappers:all",
-        "@lowrisc_rv32imcb_files//:all",
+        "@lowrisc_rv32imcb_{}_files//:all".format(host_arch),
     ],
-)
+) for host_arch in HOST_ARCHS]
 
-[setup(
-    name = device.name,
-    architecture = device.architecture,
-    artifact_naming = device.artifact_naming,
-    compiler_components = ":compiler_components",
-    constraints = device.constraints,
-    feature_set = device.feature_set,
-    include_directories = SYSTEM_INCLUDE_PATHS,
-    params = {
-        "compiler": "clang",
-    },
-    substitutions = device.substitutions,
-    tools = {
-        "ar": "wrappers/ar",
-        "cpp": "wrappers/cpp",
-        "gcc": "wrappers/clang",
-        "gcov": "wrappers/gcov",
-        "ld": "wrappers/ld",
-        "nm": "wrappers/nm",
-        "objcopy": "wrappers/objcopy",
-        "objdump": "wrappers/objdump",
-        "strip": "wrappers/strip",
-    },
-) for device in DEVICES]
+[
+    [setup(
+        name = "{}_{}".format(device.name, host_arch),
+        architecture = device.architecture,
+        artifact_naming = device.artifact_naming,
+        compiler_components = ":compiler_components" + host_arch,
+        constraints = device.constraints,
+        feature_set = device.feature_set,
+        include_directories = [path.format(host_arch) for path in SYSTEM_INCLUDE_PATHS],
+        params = {
+            "compiler": "clang",
+            "host_arch": host_arch,
+        },
+        substitutions = device.substitutions,
+        tools = {
+            "ar": "wrappers/ar",
+            "cpp": "wrappers/cpp",
+            "gcc": "wrappers/clang",
+            "gcov": "wrappers/gcov",
+            "ld": "wrappers/ld",
+            "nm": "wrappers/nm",
+            "objcopy": "wrappers/objcopy",
+            "objdump": "wrappers/objdump",
+            "strip": "wrappers/strip",
+        },
+    ) for device in DEVICES]
+    for host_arch in HOST_ARCHS
+]

--- a/toolchains/lowrisc_rv32imcb/repository.bzl
+++ b/toolchains/lowrisc_rv32imcb/repository.bzl
@@ -4,12 +4,16 @@
 
 load("@crt//rules:repo.bzl", "http_archive_or_local")
 
-def lowrisc_rv32imcb_repos(local = None):
+def lowrisc_rv32imcb_repos(local = None, host_arch = "x86_64"):
+    sha256_by_arch = {
+        "x86_64": "e8cb05d8050773330c61a254f2a6b0fce75da4d4a8951d15570b18429fd21a98",
+        "aarch64": "1b5df51abe85fb6d3cad24c62082046ab02788ef15e491040b680fcaa35a29ec",
+    }
     http_archive_or_local(
-        name = "lowrisc_rv32imcb_files",
+        name = "lowrisc_rv32imcb_{}_files".format(host_arch),
         local = local,
-        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20240923-1/lowrisc-toolchain-rv32imcb-20240923-1.tar.xz",
-        sha256 = "aeea1983553f4c81c6409abcf0d6ca33b5ed4716b2b694e7ff030523cf13486a",
-        strip_prefix = "lowrisc-toolchain-rv32imcb-20240923-1",
+        url = "https://github.com/troibe/lowrisc-toolchains/releases/download/20250225-1/lowrisc-toolchain-rv32imcb-{}-20250225-1.tar.xz".format(host_arch),
+        sha256 = sha256_by_arch[host_arch],
+        strip_prefix = "lowrisc-toolchain-rv32imcb-{}-20250225-1".format(host_arch),
         build_file = Label("//toolchains:BUILD.export_all.bazel"),
     )

--- a/toolchains/lowrisc_rv32imcb/wrappers/driver.sh
+++ b/toolchains/lowrisc_rv32imcb/wrappers/driver.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 PROG=${0##*/}
-TOOLCHAIN="lowrisc_rv32imcb_files"
+TOOLCHAIN="lowrisc_rv32imcb_$(uname -m)_files"
 PREFIX="riscv32-unknown-elf"
 
 ARGS=()


### PR DESCRIPTION
I could not find a way to read out the host architecture in `lowrisc_rv32imcb_repos`. Using `load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")` at that stage leads to cycles in the workspace file.

Instead I now download both the ARM and X86 toolchains. Next I register both and finally I let Bazel decide which one to use as part of the automatic toolchain resolution.